### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ project(':react-native-google-places').projectDir = new File(rootProject.project
 ```groovy
 dependencies {
     ...
-    compile project(':react-native-google-places')
+    implementation project(':react-native-google-places')
 }
 ```
 


### PR DESCRIPTION
compile has been (deprecated) in the latest gradle version

dependencies {
    ...
    compile project(':react-native-google-places')
    //compile has been (deprecated) in the latest gradle version

   implementation project(':react-native-google-places')
   //working fine on RN 0.63.4
}